### PR TITLE
feat: Display Steam game achievements in Game Library

### DIFF
--- a/src/components/dashboard/GameLibrary.tsx
+++ b/src/components/dashboard/GameLibrary.tsx
@@ -15,6 +15,10 @@ interface SteamGame {
   playtimeForever: number; // in minutes
   imgIconURL: string;
   imgLogoURL?: string; // Often available, good for a larger image if needed
+  achievements: { // Added this field
+    unlocked: number;
+    total: number;
+  };
 }
 
 interface GameLibraryProps {
@@ -46,7 +50,7 @@ const steamGameToGameType = (steamGame: SteamGame): Game | null => {
 
   // Default values for fields not present in Steam's GetOwnedGames API response
   const defaultLastPlayed = new Date(0).toISOString(); // Epoch time as a placeholder
-  const defaultAchievements = { unlocked: 0, total: 0 };
+  // const defaultAchievements = { unlocked: 0, total: 0 }; // Removed, as backend provides it
   const defaultStatus = 'not_installed'; // Or 'owned' - 'not_installed' seems reasonable
   const defaultGenre: string[] = ['Unknown Genre']; // Default to an array with 'Unknown Genre'
   const defaultReleaseYear = 0; // Placeholder for unknown year
@@ -59,7 +63,7 @@ const steamGameToGameType = (steamGame: SteamGame): Game | null => {
     // imageUrl: coverImg, // Redundant if GameCard uses coverImage, ensure Game uses one primary image prop
     playtime: playtimeHours,
     lastPlayed: defaultLastPlayed, // Steam API doesn't provide this in GetOwnedGames
-    achievements: defaultAchievements, // Steam API GetOwnedGames doesn't provide detailed achievement counts
+    achievements: steamGame.achievements, // Use achievements data from backend
     status: defaultStatus, // Steam API GetOwnedGames doesn't provide installation status
     genre: defaultGenre, // Steam API GetOwnedGames doesn't provide genre
     releaseYear: defaultReleaseYear, // Steam API GetOwnedGames doesn't provide release year


### PR DESCRIPTION
Extends the Steam integration to fetch and display player achievements for each Steam game in your Game Library.

Key changes:

Backend (`server/routes/steam.js`):
- The `/api/steam/user/:steamId/games` endpoint now makes an additional API call to `ISteamUserStats/GetPlayerAchievements/v1` for each game.
- It calculates unlocked and total achievements for each game.
- Includes a delay between these API calls to mitigate rate limiting.
- If fetching achievements for a specific game fails, it defaults to 0/0 for that game and logs the error.
- The game objects returned by the API now include an `achievements` field: `{ unlocked: number, total: number }`.

Frontend (`src/`):
- `src/components/dashboard/GameLibrary.tsx`:
    - Updated the `SteamGame` interface to include the `achievements` field.
    - Modified `steamGameToGameType` to map the backend's achievement data directly, removing the previous default.
- `src/components/dashboard/GameCard.tsx`:
    - Verified that existing logic correctly displays achievement progress (if total > 0) or hides the section (if total is 0). No changes were needed in this component.
- `src/components/dashboard/GameLibrary.test.tsx`:
    - Mock API responses updated to include achievement data.
    - Enhanced `GameCard` mock to verify that achievement data is correctly processed and passed down as props.

This feature provides you with a more complete overview of your Steam games directly within the dashboard.