### PR TITLE
Fix: Use relative paths for API calls and auth redirects

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -30,7 +30,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     setIsLoading(true);
     console.log('AuthContext: Attempting to fetch user. Options: { credentials: "include" }');
     try {
-      const response = await fetch('http://localhost:3000/api/user/me', { // Updated port
+      // Use relative path for fetching user data
+      const response = await fetch('/api/user/me', {
         credentials: 'include', // Crucial for sending session cookies
       });
       console.log('AuthContext: /api/user/me response status:', response.status);
@@ -54,7 +55,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     setIsLoading(true);
     console.log('AuthContext: Attempting to logout. Options: { credentials: "include" }');
     try {
-        const response = await fetch('http://localhost:3000/auth/logout', { // Updated port
+        // Use relative path for logout API call
+        const response = await fetch('/auth/logout', {
             credentials: 'include', // Crucial for sending session cookies
         });
         console.log('AuthContext: /auth/logout response status:', response.status);

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -28,7 +28,8 @@ const LoginPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
 
   const handleGoogleLogin = () => {
-    window.location.href = 'http://localhost:3000/auth/google';
+    // Use relative path for Google login
+    window.location.href = '/auth/google';
   };
 
   const validateRegistration = (): boolean => {
@@ -61,7 +62,8 @@ const LoginPage: React.FC = () => {
     }
     setIsLoginLoading(true);
     try {
-      const response = await fetch('http://localhost:3000/auth/login', {
+      // Use relative path for login API call
+      const response = await fetch('/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: loginEmail, password: loginPassword }),
@@ -91,7 +93,8 @@ const LoginPage: React.FC = () => {
     }
     setIsRegisterLoading(true);
     try {
-      const response = await fetch('http://localhost:3000/auth/register', {
+      // Use relative path for register API call
+      const response = await fetch('/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: regName, email: regEmail, password: regPassword }),


### PR DESCRIPTION
- Modified LoginPage.tsx and AuthContext.tsx to use relative paths for API calls (e.g., /auth/login, /api/user/me) instead of hardcoded localhost URLs.
- This ensures that API requests and authentication redirects correctly target the production domain when deployed, resolving the issue of redirection to localhost.