### PR TITLE
feat: Implement persistent Xbox integration and review Steam linkage

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -50,6 +50,15 @@ const UserSchema = new mongoose.Schema({
   profileUrl: {
     type: String, // URL to the Steam profile
   },
+  xboxUserId: { // For Xbox User ID (XUID)
+    type: String,
+    unique: true,
+    sparse: true,
+  },
+  xboxGamertag: { // For Xbox Gamertag
+    type: String,
+    sparse: true,
+  },
   lastLoginAt: {
     type: Date,
   },


### PR DESCRIPTION
- Add xboxUserId and xboxGamertag to User model.
- Create POST /auth/xbox/connect route to link Xbox accounts, including XUID verification and gamertag fetching via xbl.io API.
- Prevent linking an XUID already associated with another user.
- Reviewed Steam integration in passportConfig.js and auth.js; backend logic for Steam ID persistence confirmed to be sound.
- Ensured new fields are handled correctly by existing Passport deserialization.